### PR TITLE
Feature/spy reducers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
 .vscode
 dist
-resolver
-resolver
+/resolver

--- a/examples/jest-example/jest.config.js
+++ b/examples/jest-example/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
   moduleNameMapper: {
-    ...spyJestAliases("<rootDir>/node_modules", ["redux-thunk", "re-reselect", "reselect"])
+    ...spyJestAliases("<rootDir>/node_modules", ["redux-thunk", "re-reselect", "reselect", "redux"])
   },
   // The root directory that Jest should scan for tests and modules within
   rootDir: "./",

--- a/examples/jest-example/package-lock.json
+++ b/examples/jest-example/package-lock.json
@@ -377,6 +377,14 @@
         "@babel/helper-plugin-utils": "^7.16.5"
       }
     },
+    "@babel/runtime": {
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.5.tgz",
+      "integrity": "sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
@@ -5413,6 +5421,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "redux": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
+      "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/examples/jest-example/package.json
+++ b/examples/jest-example/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "performance-spy": "file:../..",
     "re-reselect": "^4.0.0",
+    "redux": "^4.1.2",
     "reselect": "^4.1.5"
   }
 }

--- a/examples/jest-example/redux-jest.js
+++ b/examples/jest-example/redux-jest.js
@@ -1,0 +1,81 @@
+const { createStore, combineReducers } = require("redux");
+
+let store;
+let middlewares;
+let initialState;
+
+describe("redux reducers performance spying", () => {
+    beforeEach(() => {
+        initialState = {
+            reducerA: {},
+            reducerB: {}
+        };
+
+        const reducerA = (state = [], action) => {
+            switch (action.type) {
+              case 'ACTION_A':
+                return {...state, [action.key]: action.value};
+              default:
+                return state
+            }
+          }
+
+        const reducerB = (state = [], action) => {
+            switch (action.type) {
+              case 'ACTION_B':
+                return {...state, [action.key]: action.value};
+              default:
+                return state
+            }
+        }
+        const reducers = {reducerA, reducerB};
+        store = createStore(combineReducers(reducers), initialState, middlewares);
+        perfStatsReset();
+    })
+
+    it("should show changed reducer once", () => {
+        store.dispatch({
+            type: 'ACTION_A',
+            key: 'mykey',
+            value: "myvalue"
+        });
+
+        const summary = getPerfSummary();
+        expect(summary.mostChangedReducers[0].key).toEqual("reducerA");
+        expect(summary.mostChangedReducers[0].changedTimes).toEqual(1);
+    })
+
+    it("should show changed reducers twice", () => {
+        store.dispatch({
+            type: 'ACTION_A',
+            key: 'mykey',
+            value: "myvalue"
+        });
+        store.dispatch({
+            type: 'ACTION_A',
+            key: 'mykey',
+            value: "othervalue"
+        });
+
+        const summary = getPerfSummary();
+        expect(summary.mostChangedReducers[0].key).toEqual("reducerA");
+        expect(summary.mostChangedReducers[0].changedTimes).toEqual(2);
+    })
+
+    it("should show changed reducers only when changed", () => {
+        store.dispatch({
+            type: 'ACTION_A',
+            key: 'mykey',
+            value: "myvalue"
+        });
+        store.dispatch({
+            type: 'ACTION_B',
+            key: 'mykey',
+            value: "othervalue"
+        });
+
+        const summary = getPerfSummary();
+        expect(summary.mostChangedReducers[0].key).toEqual("reducerA");
+        expect(summary.mostChangedReducers[0].changedTimes).toEqual(1);
+    })
+})

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
     "./resolver/re-reselect-module": {
       "import": "./resolver/re-reselect-module/dist/es/index.js",
       "require": "./resolver/re-reselect-module/dist/lib/index.js"
+    },
+    "./resolver/redux-module": {
+      "import": "./resolver/redux-module/dist/es/index.js",
+      "require": "./resolver/redux-module/dist/lib/index.js"
     }
   },
   "description": "Performance spy - spy on common libraries and check their performance",

--- a/package.json
+++ b/package.json
@@ -14,22 +14,6 @@
     ".": {
       "import": "./dist/es/index.js",
       "require": "./dist/lib/index.js"
-    },
-    "./resolver/redux-thunk-module": {
-      "import": "./resolver/redux-thunk-module/dist/es/index.js",
-      "require": "./resolver/redux-thunk-module/dist/lib/index.js"
-    },
-    "./resolver/reselect-module": {
-      "import": "./resolver/reselect-module/dist/es/index.js",
-      "require": "./resolver/reselect-module/dist/lib/index.js"
-    },
-    "./resolver/re-reselect-module": {
-      "import": "./resolver/re-reselect-module/dist/es/index.js",
-      "require": "./resolver/re-reselect-module/dist/lib/index.js"
-    },
-    "./resolver/redux-module": {
-      "import": "./resolver/redux-module/dist/es/index.js",
-      "require": "./resolver/redux-module/dist/lib/index.js"
     }
   },
   "description": "Performance spy - spy on common libraries and check their performance",
@@ -45,6 +29,7 @@
     "@types/redux": "^3.6.0",
     "jest": "^27.4.5",
     "re-reselect": "^4.0.0",
+    "redux": "^4.1.2",
     "redux-thunk": "^2.4.1",
     "reselect": "^4.1.5",
     "tslint": "^6.1.3",
@@ -53,6 +38,7 @@
   "peerDependencies": {
     "re-reselect": "^4.0.0",
     "redux-thunk": "^2.4.1",
+    "redux": "^4.1.2",
     "reselect": "^4.1.5"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,8 @@ Install library
         ...require("performance-spy").spyWebpackAliases({
             "redux-thunk": path.resolve("./node_modules/redux-thunk"),
             "reselect": path.resolve("./node_modules/reselect"),
-            "re-reselect": path.resolve("./re-reselect-module"),
+            "re-reselect": path.resolve("./node_modules/re-reselect"),
+            "redux": path.resolve("./node_modules/redux"),
         })
     }
 
@@ -58,7 +59,7 @@ You can allow it though to a specific user in production for research with some 
 
     moduleNameMapper: {
         // my name mappers...
-        ...spyJesAliases("<rootDir>/node_modules", ["redux-thunk", "re-reselect", "reselect"])
+        ...spyJesAliases("<rootDir>/node_modules", ["redux-thunk", "re-reselect", "reselect", "redux"])
     }
 
 2 - add to jest.init

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 It'll override the implentation of your favorite libraries!
 
 - React ( still WIP )
-- Redux Reducers ( still WIP )
+- Redux Reducers
 - Redux Dispatches
 - Redux Thunk
 - Moment ( not implented yet )

--- a/readme.md
+++ b/readme.md
@@ -35,12 +35,11 @@ Install library
 
     alias: {
         /* my aliases */
-        ...require("performance-spy").spyWebpackAliases({
-            "redux-thunk": path.resolve("./node_modules/redux-thunk"),
-            "reselect": path.resolve("./node_modules/reselect"),
-            "re-reselect": path.resolve("./node_modules/re-reselect"),
-            "redux": path.resolve("./node_modules/redux"),
-        })
+        ...require("performance-spy").spyWebpackAliases(path.resolve("./node_modules"), [
+          "redux-thunk",
+          "re-reselect",
+          "reselect"
+        ])
     }
 
 it'll override redux/reselect with performance-spy libraries

--- a/resolver-fixer.js
+++ b/resolver-fixer.js
@@ -32,13 +32,7 @@ for(const resolver of resolvers) {
         name: resolver,
         "main": "./dist/lib/index.js",
         "jsnext:main": "./dist/es/index.js",
-        "module": "./dist/es/index.js",
-        "exports": {
-            ".": {
-            "import": "./dist/es/index.js",
-            "require": "./dist/lib/index.js"
-            }
-        }
+        "module": "./dist/es/index.js"
     }
     fs.writeFileSync(path.join(resolverFinalPath, "./package.json"), JSON.stringify(packageData, null, "\t"), {encoding: "utf-8"})
 }

--- a/src/resolver/redux-module.ts
+++ b/src/resolver/redux-module.ts
@@ -1,0 +1,8 @@
+import * as redux from "redux-original";
+
+const _window = typeof window !== "undefined" ? window : null;
+export * from "redux-original";
+export const combineReducers = _window?.spyReducerCombiner
+  ? _window.spyReducerCombiner(redux.combineReducers)
+  : redux.combineReducers;
+

--- a/src/spy-jest/spy-jest.ts
+++ b/src/spy-jest/spy-jest.ts
@@ -1,12 +1,12 @@
 /* tslint:disable:no-console */
 export const spyJestAliases = (nodemodule: string, aliases: string[]) => {
     const finalAliases: {[key: string]: string} = {};
-    const supported = new Set(["redux-thunk", "reselect", "re-reselect"])
+    const supported = new Set(["redux-thunk", "reselect", "re-reselect", "redux"])
     for(const aliasKey of aliases) {
         if(supported.has(aliasKey)) {
             finalAliases[aliasKey+"-original(.*)"] = nodemodule+"/"+aliasKey+"$1";
+            finalAliases[aliasKey+"(.*)"] = nodemodule+"/performance-spy/resolver/"+aliasKey+"-module$1";
         }
-        finalAliases[aliasKey+"(.*)"] = nodemodule+"/performance-spy/resolver/"+aliasKey+"-module$1";
     }
 
     console.log("Overriden libraries by jest performance spier", finalAliases);

--- a/src/spy-performance/perf-spier.ts
+++ b/src/spy-performance/perf-spier.ts
@@ -4,6 +4,7 @@ import { spyCreateSelectorTime, spyCachedCreatorTime } from "./spy-functions/spy
 
 import { perfStatsReset, getPerfSummary } from "./summary/print-summary";
 import { startCustomTimer, CustomSpyFunctionsTimer } from "./custom-timer/custom-timer";
+import { spyReducerCombiner } from "./spy-functions/spy-reducers";
 
 declare global {
     interface Window {
@@ -12,6 +13,7 @@ declare global {
         spyThunk: typeof spyThunk;
         spyCreateSelectorTime: typeof spyCreateSelectorTime;
         spyCachedCreatorTime: typeof spyCachedCreatorTime;
+        spyReducerCombiner: typeof spyReducerCombiner;
         startCustomTimer: typeof startCustomTimer;
     }
 }
@@ -24,5 +26,6 @@ export const enableSpying = () => {
         window.spyCreateSelectorTime = spyCreateSelectorTime;
         window.spyCachedCreatorTime = spyCachedCreatorTime;
         window.startCustomTimer = startCustomTimer;
+        window.spyReducerCombiner = spyReducerCombiner;
     }
 }

--- a/src/spy-performance/performance-timer.ts
+++ b/src/spy-performance/performance-timer.ts
@@ -1,4 +1,4 @@
-export type Stat = 
+export type Stat =
   {
     duration?: number;
     count?: number;

--- a/src/spy-performance/performance-timer.ts
+++ b/src/spy-performance/performance-timer.ts
@@ -1,17 +1,17 @@
+export type Stat = 
+  {
+    duration?: number;
+    count?: number;
+    maxCount?: number;
+    minCount?: number;
+    moreThanFrameCount?: number;
+    'moreThan0.1s'?: number;
+  } & {
+    [key: string]: number | PerfStatsStuff
+  }
 export class PerfStatsStuff {
   type: string;
-  stats: {
-    [key: string]: {
-      duration?: number;
-      count?: number;
-      maxCount?: number;
-      minCount?: number;
-      moreThanFrameCount?: number;
-      'moreThan0.1s'?: number;
-    } & {
-      [key: string]: number | PerfStatsStuff
-    }
-  }
+  stats: {[key: string]: Stat};
 
   constructor(type: string = "") {
     this.type = type;

--- a/src/spy-performance/spy-functions/spy-reducers.ts
+++ b/src/spy-performance/spy-functions/spy-reducers.ts
@@ -21,7 +21,7 @@ function resultsChecker(_ref: any, res: any, args: IArguments, perfstat: PerfSta
     });
     return spidesReducers;
   };
-  
+
   export const spyReducerCombiner = function (reducerCombiner: GenericFunction) {
     return function (...args: any[]) {
       args[0] = spyReducers(args[0]);

--- a/src/spy-performance/spy-functions/spy-reducers.ts
+++ b/src/spy-performance/spy-functions/spy-reducers.ts
@@ -1,0 +1,30 @@
+import { spyFunctionTime } from "./spy-function-time";
+import { reducersPerfStat } from "../summary/summaries";
+import { PerfStatsStuff } from "../performance-timer";
+
+type GenericFunction = (...args: any[]) => any;
+
+function resultsChecker(_ref: any, res: any, args: IArguments, perfstat: PerfStatsStuff, key: string) {
+    const [lastState, action] = args;
+    if (res !== lastState) {
+      (perfstat.getSubStat(key, "args") as PerfStatsStuff).forwardStat("action_" + action?.type, "count");
+    }
+  }
+  const spyReducers = function (reducers: {[key: string]: GenericFunction}) {
+    const spidesReducers: {[key: string]: GenericFunction}  = {};
+    Object.keys(reducers).forEach(name => {
+      if (typeof reducers[name] === "function") {
+        spidesReducers[name] = spyFunctionTime(reducers[name], reducersPerfStat, name, { resultsChecker });
+      } else {
+        spidesReducers[name] = reducers[name];
+      }
+    });
+    return spidesReducers;
+  };
+  
+  export const spyReducerCombiner = function (reducerCombiner: GenericFunction) {
+    return function (...args: any[]) {
+      args[0] = spyReducers(args[0]);
+      return reducerCombiner(...args);
+    };
+  };

--- a/src/spy-performance/summary/print-summary.ts
+++ b/src/spy-performance/summary/print-summary.ts
@@ -3,9 +3,11 @@ import {
   allPerfStats,
   combinerPerfStat,
   dispatchPerfStat,
-  selectorsPerfStat
+  selectorsPerfStat,
+  reducersPerfStat
 } from "../summary/summaries";
 import { resetCountUpdate } from "../summary/reset-counter";
+import { PerfStatsStuff, Stat } from "../performance-timer";
 
 export const perfStatsReset = function () {
   resetCustomTimers();
@@ -14,6 +16,11 @@ export const perfStatsReset = function () {
     perfStat.reset();
   }
 };
+
+function reducerChangedTimes(r: Stat): number {
+  return Object.values((r?.args as PerfStatsStuff)?.stats || {})
+               .reduce((total, num) => total+(num.count || 0), 0);
+}
 
 export const getPerfSummary = function () {
   const longestSelectors = Object.values(selectorsPerfStat.stats)
@@ -31,12 +38,17 @@ export const getPerfSummary = function () {
     .map(([key, value]) => ({ ...value, key }))
     .sort((a, b) => (b.duration || 0) - (a.duration || 0));
 
+  const mostChangedReducers = Object.entries(reducersPerfStat.stats)
+    .map(([key, value]) => ({...value, key, changedTimes: reducerChangedTimes(value)}))
+    .sort((a, b) => (b.changedTimes || 0) - (a.changedTimes || 0));
+
   const customTimersPerfStat = getCustomTimers();
 
   return {
     longestSelectors,
     longestCombiners,
     mostCalculatedCombiners,
+    mostChangedReducers,
     longestDispatches,
     customTimersPerfStat
   };

--- a/src/spy-performance/summary/summaries.ts
+++ b/src/spy-performance/summary/summaries.ts
@@ -2,5 +2,6 @@ import { PerfStatsStuff } from "../performance-timer";
 
 export const selectorsPerfStat = new PerfStatsStuff("duration_by_key");
 export const dispatchPerfStat = new PerfStatsStuff("duration_by_key");
+export const reducersPerfStat = new PerfStatsStuff("duration_by_key_with_args");
 export const combinerPerfStat = new PerfStatsStuff("duration_by_key_with_args");
-export const allPerfStats = [selectorsPerfStat, dispatchPerfStat, combinerPerfStat];
+export const allPerfStats = [selectorsPerfStat, dispatchPerfStat, reducersPerfStat, combinerPerfStat];

--- a/src/spy-webpack/webpack-spier.ts
+++ b/src/spy-webpack/webpack-spier.ts
@@ -1,11 +1,11 @@
 /* tslint:disable:no-console */
-export function spyWebpackAliases(aliases: {[key: string]: string} = {}) {
+export function spyWebpackAliases(nodemodule: string, aliases: string[]) {
     const finalAliases: {[key: string]: string} = {};
     const supported = new Set(["redux-thunk", "reselect", "re-reselect", "redux"])
-    for(const [aliasKey, aliasNodeModulePath] of Object.entries(aliases)) {
+    for(const aliasKey of aliases) {
         if(supported.has(aliasKey)) {
-            finalAliases[aliasKey+"-original"] = aliasNodeModulePath;
-            finalAliases[aliasKey] = "performance-spy/resolver/"+aliasKey+"-module";
+            finalAliases[aliasKey+"-original"] = nodemodule+"/"+aliasKey;
+            finalAliases[aliasKey] = nodemodule+"/performance-spy/resolver/"+aliasKey+"-module";
         }
     }
     console.log("Overriden libraries by webpack performance spier", finalAliases);

--- a/src/spy-webpack/webpack-spier.ts
+++ b/src/spy-webpack/webpack-spier.ts
@@ -1,12 +1,12 @@
 /* tslint:disable:no-console */
 export function spyWebpackAliases(aliases: {[key: string]: string} = {}) {
     const finalAliases: {[key: string]: string} = {};
-    const supported = new Set(["redux-thunk", "reselect", "re-reselect"])
+    const supported = new Set(["redux-thunk", "reselect", "re-reselect", "redux"])
     for(const [aliasKey, aliasNodeModulePath] of Object.entries(aliases)) {
         if(supported.has(aliasKey)) {
             finalAliases[aliasKey+"-original"] = aliasNodeModulePath;
+            finalAliases[aliasKey] = "performance-spy/resolver/"+aliasKey+"-module";
         }
-        finalAliases[aliasKey] = "performance-spy/resolver/"+aliasKey+"-module";
     }
     console.log("Overriden libraries by webpack performance spier", finalAliases);
     return finalAliases;

--- a/src/types/re-reselect/redux.d.ts
+++ b/src/types/re-reselect/redux.d.ts
@@ -1,0 +1,3 @@
+declare module 'redux-original' {
+    export function combineReducers(): void;
+}


### PR DESCRIPTION
resolves
https://github.com/mentaman/performance-spy/issues/7

doesn't work with react-dnd@2.6.0, since they have import to 'redux/lib/createStore', and it's a different redux version
![image](https://user-images.githubusercontent.com/2057934/147388450-fa45bb31-5282-4bf7-8890-e5efa2d29128.png)

maybe it's an issue by itself that spy performance doesn't necessarily use the same packages versions if one package uses a different version of it then the one provided