### PR TITLE
context with domain

### DIFF
--- a/examples/jest-example/custom-timer-jest.js
+++ b/examples/jest-example/custom-timer-jest.js
@@ -72,11 +72,10 @@ describe("should check how long it takes to measure", () => {
         expect((end2-start2)).toBeLessThanOrEqual(getPerfSummary().customTimersPerfStat[keyB].duration)
     })
 
-    
-    it("should keep measures only in context", () => {
+    it("should keep measures only in context", async () => {
         let start, end, start2, end2;
 
-        const summary1 = getSummaryFor(() => {
+        const summary1 = await getSummaryFor(() => {
             const timer = startCustomTimer(keyA);
 
             start = performance.now();
@@ -89,7 +88,44 @@ describe("should check how long it takes to measure", () => {
             timer.end();
         })
         
-        const summary2 = getSummaryFor(() => {
+        const summary2 = await getSummaryFor(() => {
+            const timer2 = startCustomTimer(keyB);
+    
+            start2 = performance.now();
+            let txt2 = "";
+            for(let i=0; i<1000; i++) {
+                txt2 += "a";
+            }
+            end2 = performance.now();
+
+            timer2.end();
+        })
+
+        expect((end-start)).toBeLessThanOrEqual(summary1.customTimersPerfStat[keyA].duration)
+        expect((end2-start2)).toBeLessThanOrEqual(summary2.customTimersPerfStat[keyB].duration)
+    })
+    
+    it("should keep measures only in context async", async () => {
+        let start, end, start2, end2;
+
+        const delayBy = (duration) => new Promise(res => setTimeout(res, duration));
+
+        const summary1 = await getSummaryFor(async () => {
+            await delayBy(100);
+            const timer = startCustomTimer(keyA);
+            
+            start = performance.now();
+            let txt = "";
+            for(let i=0; i<1000; i++) {
+                txt += "a";
+            }
+            end = performance.now();
+    
+            timer.end();
+        })
+        
+        const summary2 = await getSummaryFor(async () => {
+            await delayBy(100);
             const timer2 = startCustomTimer(keyB);
     
             start2 = performance.now();

--- a/examples/jest-example/custom-timer-jest.js
+++ b/examples/jest-example/custom-timer-jest.js
@@ -1,3 +1,5 @@
+const { getSummaryFor } = require("performance-spy");
+
 const keyA = "measuring a";
 const keyB = "measuring b";
 
@@ -68,5 +70,39 @@ describe("should check how long it takes to measure", () => {
 
         expect((end-start)).toBeLessThanOrEqual(getPerfSummary().customTimersPerfStat[keyA].duration)
         expect((end2-start2)).toBeLessThanOrEqual(getPerfSummary().customTimersPerfStat[keyB].duration)
+    })
+
+    
+    it("should keep measures only in context", () => {
+        let start, end, start2, end2;
+
+        const summary1 = getSummaryFor(() => {
+            const timer = startCustomTimer(keyA);
+
+            start = performance.now();
+            let txt = "";
+            for(let i=0; i<1000; i++) {
+                txt += "a";
+            }
+            end = performance.now();
+    
+            timer.end();
+        })
+        
+        const summary2 = getSummaryFor(() => {
+            const timer2 = startCustomTimer(keyB);
+    
+            start2 = performance.now();
+            let txt2 = "";
+            for(let i=0; i<1000; i++) {
+                txt2 += "a";
+            }
+            end2 = performance.now();
+
+            timer2.end();
+        })
+
+        expect((end-start)).toBeLessThanOrEqual(summary1.customTimersPerfStat[keyA].duration)
+        expect((end2-start2)).toBeLessThanOrEqual(summary2.customTimersPerfStat[keyB].duration)
     })
 })

--- a/examples/jest-example/re-reselect-jest.js
+++ b/examples/jest-example/re-reselect-jest.js
@@ -60,13 +60,13 @@ describe("re-reselect performance spying", () => {
         expect(summary.mostCalculatedCombiners[0].args.stats['1'].count).toEqual(4);
     })
 
-    it("should include only current zone", () => {
-        const summary1 = getSummaryFor(() => {
+    it("should include only current zone", async () => {
+        const summary1 = await getSummaryFor(() => {
             selectorExample(1, 2, keyTwo);
             selectorExample(1, 3, keyTwo);
         });
 
-        const summary2 = getSummaryFor(() => {
+        const summary2 = await getSummaryFor(() => {
             selectorExample(1, 3, keyTwo);
             selectorExample(1, 2, keyTwo);
         });

--- a/examples/jest-example/re-reselect-jest.js
+++ b/examples/jest-example/re-reselect-jest.js
@@ -1,4 +1,5 @@
 const { createCachedSelector } = require("re-reselect");
+const { getSummaryFor } = require("performance-spy");
 
 let selectorExample;
 
@@ -57,5 +58,21 @@ describe("re-reselect performance spying", () => {
         const summary = getPerfSummary();
 
         expect(summary.mostCalculatedCombiners[0].args.stats['1'].count).toEqual(4);
+    })
+
+    it("should include only current zone", () => {
+        const summary1 = getSummaryFor(() => {
+            selectorExample(1, 2, keyTwo);
+            selectorExample(1, 3, keyTwo);
+        });
+
+        const summary2 = getSummaryFor(() => {
+            selectorExample(1, 3, keyTwo);
+            selectorExample(1, 2, keyTwo);
+        });
+
+        
+        expect(summary1.mostCalculatedCombiners[0].args.stats['1'].count).toEqual(1);
+        expect(summary2.mostCalculatedCombiners[0].args.stats['1'].count).toEqual(1);
     })
 })

--- a/readme.md
+++ b/readme.md
@@ -133,3 +133,14 @@ you can also provide data to it, for dynamic measure, to know which id had a slo
     const measureIdStuff = startCustomTimer("suspicious"+id)
     heavyFunction(id)
     measureIdStuff.end()
+
+## Measure only in specific context
+
+By default it'll measure every selector/timer and etc.
+
+You can set it to a specific context, and it'll follow changes only in this particular context
+
+    const summary2 = getSummaryFor(() => {
+        selectorExample(1, 3, keyTwo);
+        selectorExample(1, 2, keyTwo);
+    });

--- a/readme.md
+++ b/readme.md
@@ -136,11 +136,13 @@ you can also provide data to it, for dynamic measure, to know which id had a slo
 
 ## Measure only in specific context
 
+* Supported only in nodejs (jest), don't use in browser
+
 By default it'll measure every selector/timer and etc.
 
 You can set it to a specific context, and it'll follow changes only in this particular context
 
-    const summary2 = getSummaryFor(() => {
+    const summary = await getSummaryFor(() => {
         selectorExample(1, 3, keyTwo);
         selectorExample(1, 2, keyTwo);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { getSummaryFor } from "./spy-performance/summary/summary-context";
 export { spyWebpackAliases } from "./spy-webpack/webpack-spier";
 export { spyJestAliases } from "./spy-jest/spy-jest";
 export { enableSpying } from "./spy-performance/perf-spier";

--- a/src/spy-performance/summary/summary-context.ts
+++ b/src/spy-performance/summary/summary-context.ts
@@ -1,7 +1,18 @@
+import domain from "domain";
 import { Summaries } from "./summaries";
 
 export const GlobalSummaries = new Summaries();
 
+export const getSummaryFor = (func: () => void) => {
+    const summaries = new Summaries();
+    const d = domain.create();
+    (d as any).summaries = summaries;
+    d.run(() => {
+        func();
+    })
+    return summaries.getSummary();
+}
+
 export const getCurrentSummaryForUse = (): Summaries => {
-    return GlobalSummaries;
+    return (process as any)?.domain?.summaries || GlobalSummaries;
 };

--- a/src/spy-performance/summary/summary-context.ts
+++ b/src/spy-performance/summary/summary-context.ts
@@ -1,18 +1,21 @@
-import domain from "domain";
 import { Summaries } from "./summaries";
 
 export const GlobalSummaries = new Summaries();
 
-export const getSummaryFor = (func: () => void) => {
+export const getSummaryFor = async (func: () => Promise<any>) => {
     const summaries = new Summaries();
+    let promise = undefined;
+    const domain = await import("domain");
     const d = domain.create();
     (d as any).summaries = summaries;
     d.run(() => {
-        func();
+        promise = func();
     })
+    await promise;
     return summaries.getSummary();
 }
 
 export const getCurrentSummaryForUse = (): Summaries => {
+    if(typeof process === "undefined") return GlobalSummaries;
     return (process as any)?.domain?.summaries || GlobalSummaries;
 };

--- a/src/spy-performance/summary/summary-context.ts
+++ b/src/spy-performance/summary/summary-context.ts
@@ -4,7 +4,7 @@ export const GlobalSummaries = new Summaries();
 
 export const getSummaryFor = async (func: () => Promise<any>) => {
     const summaries = new Summaries();
-    let promise = undefined;
+    let promise;
     const domain = await import("domain");
     const d = domain.create();
     (d as any).summaries = summaries;


### PR DESCRIPTION
https://github.com/mentaman/performance-spy/issues/21

domain can be used only in nodejs, so useful mostly for jest tests.
Also it's a deprecated api, but there's no alternative